### PR TITLE
fix(kong-ngx-build) when prefix is specified as absolute path, do not…

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -79,7 +79,7 @@ main() {
     fatal "prefix can not be empty"
   fi
 
-  PREFIX=`pwd`/$PREFIX
+  PREFIX=`realpath $PREFIX`
 
   if [ -z "$OPENRESTY_VER" ]; then
     show_usage


### PR DESCRIPTION
… prepend `$PWD` to it