### PR TITLE
feat(pcre) include --with-pcre when building openresty

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ is so you always ends up with the same binary, every time.
 
 # Synopsis
 ```
-./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.41 --debug
+./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.43 --debug
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ is so you always ends up with the same binary, every time.
 
 # Synopsis
 ```
-./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --debug
+./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.41 --debug
 ```
 
 # Usage
@@ -16,7 +16,7 @@ is so you always ends up with the same binary, every time.
 $ ./kong-ngx-build -h
 Build basic components (OpenResty, OpenSSL and LuaRocks for Kong)
 
-Usage: ./kong-ngx-build [options...] -p <prefix> --openresty <openresty_ver> --openssl <openssl_ver>
+Usage: ./kong-ngx-build [options...] -p <prefix> --openresty <openresty_ver> --openssl <openssl_ver> --pcre <pcre_ver>
 
 Required arguments:
   -p, --prefix                  location where components should be installed to

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -369,6 +369,7 @@ show_usage() {
   echo "      --openresty               version of OpenResty to build, such as 1.13.6.2"
   echo "      --openssl                 version of OpenSSL to build, such as 1.1.1b"
   echo "Optional arguments:"
+  echo "      --pcre                    version of PCRE to use to build, such as 8.43"
   echo "      --no-build-cache          disable compilation caching and re-download source code to"
   echo "                                build from scratch"
   echo -e "                                \033[1;31mWARNING:\033[0m this removes everything inside the work directory"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -11,6 +11,7 @@ LUAROCKS_VER=
 BUILD_CACHE=1
 ARTIFACT_CACHE=1
 OPENRESTY_PATCHES=1
+RESTY_PCRE_VER=8.41
 DEBUG=0
 NPROC=`nproc`
 OS=
@@ -28,6 +29,14 @@ main() {
         ;;
       -j|--jobs)
         NPROC=$2
+        shift 2
+        ;;
+      --pcre)
+        RESTY_PCRE_VER=$2
+        shift 2
+        ;;
+      --pcre_sha)
+        PCRE_SHA=$2
         shift 2
         ;;
       --openresty)
@@ -219,6 +228,21 @@ main() {
         curl -s -S -L https://github.com/Kong/openresty-patches/archive/master.tar.gz | tar xz
       popd
     fi
+    
+    PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$RESTY_PCRE_VER
+    PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
+    if [ ! -z "$RESTY_PCRE_VER" ]; then
+      if [ ! -d $PCRE_DOWNLOAD ]; then
+        warn "PCRE source not found, downloading..."
+        pushd $DOWNLOAD_CACHE
+          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz
+          if [ ! -z ${PCRE_SHA+x} ]; then
+            echo "$PCRE_SHA pcre-${RESTY_PCRE_VERSION}.tar.gz" | sha256sum -c -
+          fi
+          tar -xzvf pcre-${RESTY_PCRE_VERSION}.tar.gz
+        popd
+      fi
+    fi
 
     warn "Building OpenResty..."
 
@@ -230,6 +254,7 @@ main() {
           "--prefix=$OPENRESTY_INSTALL"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
           "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENSSL_INSTALL/lib'"
+          "--with-pcre=$PCRE_LOCATION"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -8,10 +8,10 @@ DOWNLOAD_CACHE=work
 OPENRESTY_VER=
 OPENSSL_VER=
 LUAROCKS_VER=
+PCRE_VER=
 BUILD_CACHE=1
 ARTIFACT_CACHE=1
 OPENRESTY_PATCHES=1
-RESTY_PCRE_VER=8.41
 DEBUG=0
 NPROC=`nproc`
 OS=
@@ -32,7 +32,7 @@ main() {
         shift 2
         ;;
       --pcre)
-        RESTY_PCRE_VER=$2
+        PCRE_VER=$2
         shift 2
         ;;
       --pcre_sha)
@@ -229,17 +229,17 @@ main() {
       popd
     fi
     
-    PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$RESTY_PCRE_VER
-    PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
-    if [ ! -z "$RESTY_PCRE_VER" ]; then
+    if [ ! -z "$PCRE_VER" ]; then
+      PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
+      PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
       if [ ! -d $PCRE_DOWNLOAD ]; then
         warn "PCRE source not found, downloading..."
         pushd $DOWNLOAD_CACHE
-          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz
+          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VER}.tar.gz
           if [ ! -z ${PCRE_SHA+x} ]; then
-            echo "$PCRE_SHA pcre-${RESTY_PCRE_VERSION}.tar.gz" | sha256sum -c -
+            echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
           fi
-          tar -xzvf pcre-${RESTY_PCRE_VERSION}.tar.gz
+          tar -xzvf pcre-${PCRE_VER}.tar.gz
         popd
       fi
     fi
@@ -254,7 +254,6 @@ main() {
           "--prefix=$OPENRESTY_INSTALL"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
           "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENSSL_INSTALL/lib'"
-          "--with-pcre=$PCRE_LOCATION"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"
@@ -264,12 +263,16 @@ main() {
           "--with-stream_realip_module"
           "-j$NPROC"
         )
+        
+        if [ ! -z "$PCRE_VER" ]; then
+          OPENRESTY_OPTS+=('--with-pcre=$PCRE_LOCATION')
+        fi
 
         OPENRESTY_OPTS+=(${NGINX_EXTRA_MODULES[@]})
 
         if [ $DEBUG == 1 ]; then
-            OPENRESTY_OPTS+=('--with-debug')
-            OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
+          OPENRESTY_OPTS+=('--with-debug')
+          OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
         fi
 
         if [ $OPENRESTY_PATCHES == 1 ]; then


### PR DESCRIPTION
@dndx and I both think this likely isn't necessary but to maintain backwards compatibility with how https://github.com/Kong/kong-build-tools going to include it.

I decided to set a default of `RESTY_PCRE_VER=8.41` which should be fine for most versions of Kong so this change should be mostly backwards compatible