### PR TITLE
fix(patches) adjust how we switch openresty patches branch

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -229,8 +229,8 @@ main() {
 
         pushd openresty-patches
           notice "Checking out branch '$OPENRESTY_PATCHES' of Kong's OpenResty patches..."
-          git checkout -f -b $OPENRESTY_PATCHES origin/$OPENRESTY_PATCHES
-          git pull
+          git fetch
+          git reset --hard origin/$OPENRESTY_PATCHES
         popd
       popd
     fi


### PR DESCRIPTION
Should resolve the following errors;
```
./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.1.2 --debug
......
WARN: Kong OpenResty patches not found, cloning...
Cloning into 'openresty-patches'...
remote: Enumerating objects: 107, done.
remote: Counting objects: 100% (107/107), done.
remote: Compressing objects: 100% (73/73), done.
remote: Total 239 (delta 41), reused 82 (delta 29), pack-reused 132
Receiving objects: 100% (239/239), 126.56 KiB | 3.42 MiB/s, done.
Resolving deltas: 100% (96/96), done.
/src/work/openresty-patches /src/work /src
NOTICE: Checking out branch 'master' of Kong's OpenResty patches...
fatal: A branch named 'master' already exists.
root@416406a5848a:/src# echo $?
128
```