### PR TITLE
feat(packaging) adjust so we can install to one packagable location

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ is so you always ends up with the same binary, every time.
 
 # Synopsis
 ```
-./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.41 --debug
+./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.43 --debug
 ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Optional ENV:
 
 The following ENV's are likely only utilized when building for the purposes of packaging Kong
 
-  LUAROCKS_INSTALL                 Overrides the `./config --prefix` value (default is `--prefix/luarocks`)
+  LUAROCKS_INSTALL                 Overrides the `./config --prefix` value (default is `<prefix>/luarocks`)
   
   LUAROCKS_DESTDIR                 Overrides the `make install DESTDIR` (default is `/`)
   

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ is so you always ends up with the same binary, every time.
 
 # Synopsis
 ```
-./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --debug
+./kong-ngx-build -p buildroot --openresty 1.13.6.2 --openssl 1.1.1b --luarocks 3.0.4 --pcre 8.41 --debug
 ```
 
 # Usage
@@ -16,7 +16,7 @@ is so you always ends up with the same binary, every time.
 $ ./kong-ngx-build -h
 Build basic components (OpenResty, OpenSSL and LuaRocks for Kong)
 
-Usage: ./kong-ngx-build [options...] -p <prefix> --openresty <openresty_ver> --openssl <openssl_ver>
+Usage: ./kong-ngx-build [options...] -p <prefix> --openresty <openresty_ver> --openssl <openssl_ver> --pcre <pcre_ver>
 
 Required arguments:
   -p, --prefix                  location where components should be installed to

--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ Optional arguments:
                                    (Defaults to "work")
 
   -h, --help                       Show this message.
+
+Optional ENV:
+
+The following ENV's are likely only utilized when building for the purposes of packaging Kong
+
+  LUAROCKS_INSTALL                 Overrides the `./config --prefix` value (default is `--prefix/luarocks`)
+  
+  LUAROCKS_DESTDIR                 Overrides the `make install DESTDIR` (default is `/`)
+  
+  OPENRESTY_INSTALL                Overrides the `./config --prefix` value (default is `--prefix/openresty)
+  
+  OPENRESTY_DESTDIR                Overrides the `make install DESTDIR` (default is `/`)
+  
+  OPENSSL_INSTALL                  Overrides the `./config --prefix` value (default is `--prefix/openssl)
+  
+  OPENRESTY_RPATH                  Overrides the `make install DESTDIR` (default is `/`)
+  
 ```
 
 # Caching

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -154,6 +154,7 @@ main() {
   notice "Building the components now..."
 
   OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
+  OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
   OPENRESTY_INSTALL=$PREFIX/openresty
 
   if [ ! -f $OPENSSL_INSTALL/bin/openssl ]; then
@@ -254,7 +255,7 @@ main() {
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_INSTALL"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
-          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENSSL_INSTALL/lib'"
+          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -155,7 +155,8 @@ main() {
 
   OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
   OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
-  OPENRESTY_INSTALL=$PREFIX/openresty
+  OPENRESTY_INSTALL=${OPENRESTY_INSTALL:-$PREFIX/openresty}
+  OPENRESTY_DESTDIR=${OPENRESTY_DESTDIR:-/}
 
   if [ ! -f $OPENSSL_INSTALL/bin/openssl ]; then
     if [ ! -d $OPENSSL_DOWNLOAD ]; then
@@ -242,6 +243,7 @@ main() {
             echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
           fi
           tar -xzvf pcre-${PCRE_VER}.tar.gz
+          ln -s pcre-$OPENSSL_VER pcre
         popd
       fi
     fi
@@ -305,7 +307,7 @@ main() {
       fi
 
       make -j$NPROC
-      make install
+      make -j$NPROC install DESTDIR=${OPENRESTY_DESTDIR}
     popd
 
     succ "OpenResty $OPENRESTY_VER has been built successfully!"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -165,6 +165,7 @@ main() {
           echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
         fi
         tar -xzvf openssl-$OPENSSL_VER.tar.gz
+        ln -s openssl-$OPENSSL_VER openssl
       popd
     fi
 

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -234,7 +234,6 @@ main() {
     
     if [ ! -z "$PCRE_VER" ]; then
       PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
-      PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
       if [ ! -d $PCRE_DOWNLOAD ]; then
         warn "PCRE source not found, downloading..."
         pushd $DOWNLOAD_CACHE
@@ -269,7 +268,7 @@ main() {
         )
         
         if [ ! -z "$PCRE_VER" ]; then
-          OPENRESTY_OPTS+=('--with-pcre=$PCRE_LOCATION')
+          OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')
         fi
 
         OPENRESTY_OPTS+=(${NGINX_EXTRA_MODULES[@]})

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -11,6 +11,7 @@ LUAROCKS_VER=
 BUILD_CACHE=1
 ARTIFACT_CACHE=1
 OPENRESTY_PATCHES=1
+RESTY_PCRE_VER=8.41
 DEBUG=0
 NPROC=`nproc`
 OS=
@@ -28,6 +29,14 @@ main() {
         ;;
       -j|--jobs)
         NPROC=$2
+        shift 2
+        ;;
+      --pcre)
+        RESTY_PCRE_VER=$2
+        shift 2
+        ;;
+      --pcre_sha)
+        PCRE_SHA=$2
         shift 2
         ;;
       --openresty)
@@ -219,6 +228,21 @@ main() {
         curl -s -S -L https://github.com/Kong/openresty-patches/archive/master.tar.gz | tar xz
       popd
     fi
+    
+    PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$RESTY_PCRE_VER
+    PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
+    if [ ! -z "$RESTY_PCRE_VER" ]; then
+      if [ ! -d $PCRE_DOWNLOAD ]; then
+        warn "PCRE source not found, downloading..."
+        pushd $DOWNLOAD_CACHE
+          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz
+          if [ ! -z ${PCRE_SHA+x} ]; then
+            echo "$PCRE_SHA pcre-${RESTY_PCRE_VERSION}.tar.gz" | sha256sum -c -
+          fi
+          tar -xzvf pcre-${RESTY_PCRE_VERSION}.tar.gz
+        popd
+      fi
+    fi
 
     warn "Building OpenResty..."
 
@@ -230,6 +254,7 @@ main() {
           "--prefix=$OPENRESTY_INSTALL"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
           "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENSSL_INSTALL/lib'"
+          "--with-pcre=$PCRE_LOCATION"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -157,11 +157,12 @@ main() {
   notice "Building the components now..."
 
   OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
+  OPENSSL_DESTDIR=${OPENSSL_DESTDIR:-/}
   OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
   OPENRESTY_INSTALL=${OPENRESTY_INSTALL:-$PREFIX/openresty}
   OPENRESTY_DESTDIR=${OPENRESTY_DESTDIR:-/}
 
-  if [ ! -f $OPENSSL_INSTALL/bin/openssl ]; then
+  if [ ! -f $OPENSSL_DESTDIR$OPENSSL_INSTALL/bin/openssl ]; then
     if [ ! -d $OPENSSL_DOWNLOAD ]; then
       warn "OpenSSL source not found, downloading..."
       pushd $DOWNLOAD_CACHE
@@ -198,11 +199,11 @@ main() {
             OPENSSL_OPTS+=('-d')
           fi
 
-        eval ./config ${OPENSSL_OPTS[*]}
+        eval ./config ${OPENSSL_OPTS[*]} "-Wl,--enable-new-dtags,-rpath,'\$(LIBRPATH)'"
       fi
 
       make -j$NPROC
-      make install_sw
+      make install_sw DESTDIR=${OPENSSL_DESTDIR}
     popd
 
     succ "OpenSSL $OPENSSL_VER has been built successfully!"
@@ -268,8 +269,8 @@ main() {
       if [ ! -f Makefile ]; then
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_INSTALL"
-          "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
-          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'"
+          "--with-cc-opt='-I$OPENSSL_DESTDIR$OPENSSL_INSTALL/include'"
+          "--with-ld-opt='-L$OPENSSL_DESTDIR$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -153,7 +153,7 @@ main() {
 
   notice "Building the components now..."
 
-  OPENSSL_INSTALL=$PREFIX/openssl
+  OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
   OPENRESTY_INSTALL=$PREFIX/openresty
 
   if [ ! -d $OPENSSL_INSTALL ]; then

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -156,7 +156,7 @@ main() {
   OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
   OPENRESTY_INSTALL=$PREFIX/openresty
 
-  if [ ! -d $OPENSSL_INSTALL ]; then
+  if [ ! -f $OPENSSL_INSTALL/bin/openssl ]; then
     if [ ! -d $OPENSSL_DOWNLOAD ]; then
       warn "OpenSSL source not found, downloading..."
       pushd $DOWNLOAD_CACHE

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -314,9 +314,10 @@ main() {
 
 
   if [ ! -z "$LUAROCKS_VER" ]; then
-    LUAROCKS_INSTALL=$PREFIX/luarocks
-
-    if [ ! -d $LUAROCKS_INSTALL ]; then
+    LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
+    LUAROCKS_DESTDIR=${LUAROCKS_DESTDIR:-/}
+    
+    if [ ! -f $LUAROCKS_DESTDIR$LUAROCKS_INSTALL/bin/luarocks ]; then
       LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS_VER
 
       if [ ! -d $LUAROCKS_DOWNLOAD ]; then
@@ -342,7 +343,7 @@ main() {
         fi
 
         make build -j$NPROC
-        make install
+        make install DESTDIR=$LUAROCKS_DESTDIR
       popd
 
       succ "LuaRocks $LUAROCKS_VER has been built successfully!"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -452,3 +452,5 @@ err() {
 }
 
 main $@
+
+# vi: ts=2 sts=2 sw=2 et

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -204,7 +204,7 @@ main() {
     succ "OpenSSL $OPENSSL_VER has been built successfully (cached)!"
   fi
 
-  if [ ! -d $OPENRESTY_INSTALL ]; then
+  if [ ! -f $OPENRESTY_DESTDIR$OPENRESTY_INSTALL/nginx/sbin/nginx ]; then
     if [[ $OPENRESTY_PATCHES == 0 && -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]]; then
       notice "Patched OpenResty found, removing..."
       rm -rf $OPENRESTY_DOWNLOAD
@@ -316,7 +316,6 @@ main() {
     succ "OpenResty $OPENRESTY_VER has been built successfully (cached)!"
   fi
 
-
   if [ ! -z "$LUAROCKS_VER" ]; then
     LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
     LUAROCKS_DESTDIR=${LUAROCKS_DESTDIR:-/}
@@ -342,12 +341,12 @@ main() {
           ./configure \
             --prefix=$LUAROCKS_INSTALL \
             --lua-suffix=jit \
-            --with-lua=$OPENRESTY_INSTALL/luajit \
-            --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1
+            --with-lua=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit \
+            --with-lua-include=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit/include/luajit-2.1
         fi
 
         make build -j$NPROC
-        make install DESTDIR=$LUAROCKS_DESTDIR
+        make install DESTDIR=${LUAROCKS_DESTDIR}
       popd
 
       succ "LuaRocks $LUAROCKS_VER has been built successfully!"

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -8,10 +8,10 @@ DOWNLOAD_CACHE=work
 OPENRESTY_VER=
 OPENSSL_VER=
 LUAROCKS_VER=
+PCRE_VER=
 BUILD_CACHE=1
 ARTIFACT_CACHE=1
 OPENRESTY_PATCHES=1
-RESTY_PCRE_VER=8.41
 DEBUG=0
 NPROC=`nproc`
 OS=
@@ -32,7 +32,7 @@ main() {
         shift 2
         ;;
       --pcre)
-        RESTY_PCRE_VER=$2
+        PCRE_VER=$2
         shift 2
         ;;
       --pcre_sha)
@@ -229,17 +229,17 @@ main() {
       popd
     fi
     
-    PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$RESTY_PCRE_VER
-    PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
-    if [ ! -z "$RESTY_PCRE_VER" ]; then
+    if [ ! -z "$PCRE_VER" ]; then
+      PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
+      PCRE_LOCATION=`realpath $PCRE_DOWNLOAD`
       if [ ! -d $PCRE_DOWNLOAD ]; then
         warn "PCRE source not found, downloading..."
         pushd $DOWNLOAD_CACHE
-          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${RESTY_PCRE_VERSION}.tar.gz
+          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VER}.tar.gz
           if [ ! -z ${PCRE_SHA+x} ]; then
-            echo "$PCRE_SHA pcre-${RESTY_PCRE_VERSION}.tar.gz" | sha256sum -c -
+            echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
           fi
-          tar -xzvf pcre-${RESTY_PCRE_VERSION}.tar.gz
+          tar -xzvf pcre-${PCRE_VER}.tar.gz
         popd
       fi
     fi
@@ -254,7 +254,6 @@ main() {
           "--prefix=$OPENRESTY_INSTALL"
           "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
           "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENSSL_INSTALL/lib'"
-          "--with-pcre=$PCRE_LOCATION"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"
@@ -264,12 +263,16 @@ main() {
           "--with-stream_realip_module"
           "-j$NPROC"
         )
+        
+        if [ ! -z "$PCRE_VER" ]; then
+          OPENRESTY_OPTS+=('--with-pcre=$PCRE_LOCATION')
+        fi
 
         OPENRESTY_OPTS+=(${NGINX_EXTRA_MODULES[@]})
 
         if [ $DEBUG == 1 ]; then
-            OPENRESTY_OPTS+=('--with-debug')
-            OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
+          OPENRESTY_OPTS+=('--with-debug')
+          OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
         fi
 
         if [ $OPENRESTY_PATCHES == 1 ]; then


### PR DESCRIPTION
edited to add: I tried this branch via gojira and it worked. It's currently being used by this PR in kong-build-tools as well https://github.com/Kong/kong-build-tools/pull/86 and working

for the purposes of packaging Kong for distribution purposes we need:
- openssl to be in `/usr/local/kong/` so it doesn't risk colliding with system openssl
- luarocks to be in `/usr/local/bin/luarocks` so it's available at default path expectations

managed to achieve this in a backwards compatible way by letting ENV's override specific compile / build / install parameters

```
    LUAROCKS_INSTALL=/usr/local \
    LUAROCKS_DESTDIR=/tmp/build \
    OPENRESTY_INSTALL=/usr/local/openresty \
    OPENRESTY_DESTDIR=/tmp/build \
    OPENSSL_INSTALL=/tmp/build/usr/local/kong \
    OPENRESTY_RPATH=/usr/local/kong/lib \
    /tmp/kong-ngx-build -p /tmp/build/usr/local \
        --openresty $RESTY_VERSION \
        --openssl $RESTY_OPENSSL_VERSION \
        --luarocks $RESTY_LUAROCKS_VERSION \
        --pcre $RESTY_PCRE_VERSION
```