### PR TITLE
Disable openresty flags that do not work on older openssl versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,13 @@ compiler:
 
 jobs:
   include:
-    # Known builds we want to succeed
-    - script: ./kong-ngx-build --prefix prefix --openresty 1.11.2.5 --openssl 1.0.2n --luarocks 2.4.3 --no-openresty-patches
-    - script: ./kong-ngx-build --prefix prefix --openresty 1.13.6.2 --openssl 1.1.1c --luarocks 3.1.3
+    - stage: test
+      script: bash t/*.sh
+
+    - stage: integration
+      # Known builds we want to succeed
+      script: ./kong-ngx-build --prefix prefix --openresty 1.11.2.5 --openssl 1.0.2n --luarocks 2.4.3 --no-openresty-patches
+      script: ./kong-ngx-build --prefix prefix --openresty 1.13.6.2 --openssl 1.1.1c --luarocks 3.1.3
 
 cache:
   apt: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+dist: xenial
+sudo: required
+
+language: generic
+
+addons:
+  apt:
+    packages:
+     - build-essential
+     - perl
+     - curl
+
+compiler:
+  - gcc
+  - clang
+
+jobs:
+  include:
+    # Known builds we want to succeed
+    - script: ./kong-ngx-build --prefix prefix --openresty 1.11.2.5 --openssl 1.0.2n --luarocks 2.4.3 --no-openresty-patches
+    - script: ./kong-ngx-build --prefix prefix --openresty 1.13.6.2 --openssl 1.1.1c --luarocks 3.1.3
+
+cache:
+  apt: true

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -449,6 +449,16 @@ version_gt() {
   return 0
 }
 
+version_lte() {
+  (version_lt $1 $2 || version_eq $1 $2) && return 0
+  return 1
+}
+
+version_gte() {
+  (version_gt $1 $2 || version_eq $1 $2) && return 0
+  return 1
+}
+
 show_usage() {
   echo "Build basic components (OpenResty, OpenSSL and LuaRocks) for Kong."
   echo ""

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -531,6 +531,8 @@ err() {
   exit 1
 }
 
-main $@
+if [[ $(basename $(realpath $0)) == "kong-ngx-build" ]]; then
+  main $@
+fi
 
 # vi: ts=2 sts=2 sw=2 et

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -279,7 +279,7 @@ main() {
     notice "Building OpenSSL..."
 
     pushd $OPENSSL_DOWNLOAD
-      if (version_eq $OPENSSL_VER 1.0 && [[ ! -d include/openssl ]]) || [[ ! -f Makefile ]]; then
+      if (version_lt $OPENSSL_VER 1.1.0 && [[ ! -d include/openssl ]]) || [[ ! -f Makefile ]]; then
           OPENSSL_OPTS=(
             "-g"
             "shared"
@@ -289,7 +289,7 @@ main() {
             "--openssldir=$OPENSSL_INSTALL"
           )
 
-          if version_eq $OPENSSL_VER 1.1; then
+          if version_gte $OPENSSL_VER 1.1.0; then
             OPENSSL_OPTS+=('no-unit-test')
 
           else
@@ -332,13 +332,11 @@ main() {
           "-j$NPROC"
         )
 
-        if version_gt $OPENRESTY_VER 1.11.3; then
-          # 1.11.4
+        if version_gte $OPENRESTY_VER 1.11.4; then
           OPENRESTY_OPTS+=('--with-stream_realip_module')
         fi
 
-        if version_gt $OPENRESTY_VER 1.11.4; then
-          # 1.11.5
+        if version_gte $OPENRESTY_VER 1.11.5; then
           OPENRESTY_OPTS+=('--with-stream_ssl_preread_module')
         fi
 

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -261,7 +261,7 @@ main() {
 
     # apply non Kong-specific patches
 
-    if [[ $OPENRESTY_VER == 1.13.6.* ]]; then
+    if version_eq $OPENRESTY_VER 1.13.6; then
       if [[ $OS == "Fedora" && $OS_VER -gt 28 ]]; then
         warn "Fedora 28 or above detected, applying 'rm_glibc_crypt_r_workaround' patch..."
         pushd $OPENRESTY_DOWNLOAD/bundle/nginx-1.13.6
@@ -279,7 +279,7 @@ main() {
     notice "Building OpenSSL..."
 
     pushd $OPENSSL_DOWNLOAD
-      if [[ ($OPENSSL_VER == 1.0.* && ! -d include/openssl) || ! -f Makefile ]]; then
+      if (version_eq $OPENSSL_VER 1.0 && [[ ! -d include/openssl ]]) || [[ ! -f Makefile ]]; then
           OPENSSL_OPTS=(
             "-g"
             "shared"
@@ -289,7 +289,7 @@ main() {
             "--openssldir=$OPENSSL_INSTALL"
           )
 
-          if [[ $OPENSSL_VER == 1.1.* ]]; then
+          if version_eq $OPENSSL_VER 1.1; then
             OPENSSL_OPTS+=('no-unit-test')
 
           else
@@ -385,6 +385,48 @@ main() {
   fi
 
   succ "Build finished in $SECONDS seconds. Enjoy!"
+}
+
+parse_version() {
+    # in foo-x.y.z-foobar captures x y z
+    local re='[^0-9]*([0-9a-zA-Z]*)(?:[.]([0-9a-zA-Z]*))?(?:[.]([0-9a-zA-Z]*))?.*'
+    eval $2=`echo $1 | perl -0777 -pe "s/$re/\1/s"`
+    eval $3=`echo $1 | perl -0777 -pe "s/$re/\2/s"`
+    eval $4=`echo $1 | perl -0777 -pe "s/$re/\3/s"`
+}
+
+version_eq() {
+    parse_version $1 major_a minor_a revision_a
+    parse_version $2 major_b minor_b revision_b
+
+    [[ $major_a    = $major_b    ]] &&
+    [[ $minor_a    = $minor_b    ]] &&
+    # Note how 1.1.1 == 1.1 (comparisons again major.minor)
+    [[ -z $revision_b || $revision_a = $revision_b ]] && return 0
+
+    return 1
+}
+
+version_lt() {
+    parse_version $1 major_a minor_a revision_a
+    parse_version $2 major_b minor_b revision_b
+
+    [[ $major_a < $major_b ]] && return 0
+
+    [[ $major_a = $major_b ]] &&
+    [[ $minor_a < $minor_b ]] && return 0
+
+    [[ $major_a    = $major_b    ]] &&
+    [[ $minor_a    = $minor_b    ]] &&
+    [[ $revision_a < $revision_b ]] && return 0
+
+    return 1
+}
+
+version_gt() {
+    version_eq $1 $2 && return 1
+    version_lt $1 $2 && return 1
+    return 0
 }
 
 show_usage() {

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -396,45 +396,57 @@ main() {
 }
 
 parse_version() {
-    # in foo-x.y.z-foobar captures x y z
-    local re='[^0-9]*([0-9a-zA-Z]*)(?:[.]([0-9a-zA-Z]*))?(?:[.]([0-9a-zA-Z]*))?.*'
-    eval $2=`echo $1 | perl -0777 -pe "s/$re/\1/s"`
-    eval $3=`echo $1 | perl -0777 -pe "s/$re/\2/s"`
-    eval $4=`echo $1 | perl -0777 -pe "s/$re/\3/s"`
+  [[ -z $1 || -z $2 ]] && return 1
+
+  # remove non-version parts of a version, ie foobar-1.2.3a.5-rc1 -> 1.2.3a.5
+  local re='^[^0-9]*([0-9a-zA-Z.]*).*$'
+  local version=$(echo $1 | perl -0777 -pe "s/$re/\1/s")
+
+  IFS='.' read -r -a $2 <<< "$version"
 }
 
 version_eq() {
-    parse_version $1 major_a minor_a revision_a
-    parse_version $2 major_b minor_b revision_b
+  local version_a version_b
 
-    [[ $major_a    = $major_b    ]] &&
-    [[ $minor_a    = $minor_b    ]] &&
-    # Note how 1.1.1 == 1.1 (comparisons again major.minor)
-    [[ -z $revision_b || $revision_a = $revision_b ]] && return 0
+  parse_version $1 version_a
+  parse_version $2 version_b
 
-    return 1
+  # Note that we are indexing on the b components, ie: 1.11.100 == 1.11
+  for index in "${!version_b[@]}"; do
+    [[ "${version_a[index]}" != "${version_b[index]}" ]] && return 1
+  done
+
+  return 0
 }
 
 version_lt() {
-    parse_version $1 major_a minor_a revision_a
-    parse_version $2 major_b minor_b revision_b
+  local version_a version_b
 
-    [[ $major_a < $major_b ]] && return 0
+  parse_version $1 version_a
+  parse_version $2 version_b
 
-    [[ $major_a = $major_b ]] &&
-    [[ $minor_a < $minor_b ]] && return 0
+  local alpha_num_re='^([0-9]+)([a-zA-Z]*)$'
+  local num_a num_b
+  local alp_a alp_b
 
-    [[ $major_a    = $major_b    ]] &&
-    [[ $minor_a    = $minor_b    ]] &&
-    [[ $revision_a < $revision_b ]] && return 0
+  for index in "${!version_a[@]}"; do
+    num_a=$(echo ${version_a[index]} | perl -0777 -pe "s/$alpha_num_re/\1/s")
+    num_b=$(echo ${version_b[index]} | perl -0777 -pe "s/$alpha_num_re/\1/s")
+    [[ "$num_a" -lt "$num_b" ]] && return 0
+    [[ "$num_a" -gt "$num_b" ]] && return 1
 
-    return 1
+    alp_a=$(echo ${version_a[index]} | perl -0777 -pe "s/$alpha_num_re/\2/s")
+    alp_b=$(echo ${version_b[index]} | perl -0777 -pe "s/$alpha_num_re/\2/s")
+    [[ "$alp_a" < "$alp_b" ]] && return 0
+    [[ "$alp_a" > "$alp_b" ]] && return 1
+  done
+
+  return 1
 }
 
 version_gt() {
-    version_eq $1 $2 && return 1
-    version_lt $1 $2 && return 1
-    return 0
+  (version_eq $1 $2 || version_lt $1 $2) && return 1
+  return 0
 }
 
 show_usage() {

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -329,10 +329,18 @@ main() {
           "--with-http_realip_module"
           "--with-http_stub_status_module"
           "--with-http_v2_module"
-          "--with-stream_ssl_preread_module"
-          "--with-stream_realip_module"
           "-j$NPROC"
         )
+
+        if version_gt $OPENRESTY_VER 1.11.3; then
+          # 1.11.4
+          OPENRESTY_OPTS+=('--with-stream_realip_module')
+        fi
+
+        if version_gt $OPENRESTY_VER 1.11.4; then
+          # 1.11.5
+          OPENRESTY_OPTS+=('--with-stream_ssl_preread_module')
+        fi
 
         if [ ! -z "$PCRE_VER" ]; then
           OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')

--- a/t/001_test_version.sh
+++ b/t/001_test_version.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+source $(dirname $(realpath $0))/../kong-ngx-build
+
+set +e
+
+g_ok=0
+
+function t() {
+    local res ok
+
+    >&2 printf "t: $1 ? $2... "
+    eval $1
+    res=$?
+
+    test $res -eq $2
+    ok=$?
+
+    if [[ ! $res -eq $2 ]]; then
+        >&2 printf "\e[091merr: $res\e[0m\n"
+    else
+        >&2 printf "\e[092mok\n\e[0m"
+    fi
+
+    [[ $g_ok = 1 ]] || g_ok=$ok
+
+    return $ok
+}
+
+t "version_eq 1.11.10 1.11.10" 0
+t "version_eq 1.11.10 1.11" 0
+t "version_eq 1.11.11.11 1.11.11.11" 0
+
+t "version_eq 1.11.10 1.11.11" 1
+t "version_eq 1.11.11.11.10.11 1.11.11.11.11.11.11" 1
+
+t "version_eq 1.11.12a 1.11.12a" 0
+t "version_eq 1.11.12a 1.11" 0
+
+t "version_eq a.b.c a.b.c" 0
+t "version_eq a.b.c.d a.b.c" 0
+
+
+t "version_lt 1.11.10 1.11.11" 0
+t "version_lt 1.10.11 1.11.11" 0
+t "version_lt 0.11.11 1.11.11" 0
+t "version_lt 1.11.10.11.11 1.11.11.11.11" 0
+
+t "version_lt 1.11.0 1.11.0" 1
+t "version_lt 1.12.0 1.11.0" 1
+t "version_lt 2.12.0 1.11.0" 1
+
+t "version_lt 1.11.10a 1.11.11b" 0
+t "version_lt 1.11.10a 1.11.11bc" 0
+t "version_lt 1.11.10ab 1.11.11bc" 0
+
+
+t "version_gt 1.12.0 1.11.0" 0
+t "version_gt 1.12.0 1.11.0" 0
+t "version_gt 2.12.0 1.11.0" 0
+t "version_gt 1.11.10.11.11 1.10.11.11.11" 0
+
+t "version_gt 1.11.10 1.11.11" 1
+t "version_gt 1.10.11 1.11.11" 1
+t "version_gt 0.11.11 1.11.11" 1
+t "version_gt 1.11.10.11.11 1.11.11.11.11" 1
+
+t "version_gt 1.11.0 1.11.0" 1
+
+t "version_gt 1.11.10z 1.11.10b" 0
+t "version_gt 1.11.11bc 1.11.11aa" 0
+t "version_gt 1.11.10z 1.11.11b" 1
+
+t "version_lte 1.11.10 1.11.10" 0
+t "version_lte 1.11.10 1.11.11" 0
+t "version_lte 1.11.12 1.11.11" 1
+
+t "version_gte 1.11.10 1.11.10" 0
+t "version_gte 1.11.12 1.11.11" 0
+t "version_gte 1.11.10 1.11.11" 1
+
+exit $g_ok


### PR DESCRIPTION
* Disables openresty build flags that do not work with older openssl versions.
* Sends build output to stdout to clear up stderr. Open to a better approach to make the command less verbose.