### PR TITLE
fix(kong-ngx-build) actually apply Kong's OpenResty patches

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -118,6 +118,7 @@ main() {
   fi
 
   PREFIX=`realpath $PREFIX`
+  DOWNLOAD_CACHE=`realpath $DOWNLOAD_CACHE`
 
   if [ -z "$OPENRESTY_VER" ]; then
     show_usage
@@ -295,7 +296,7 @@ main() {
         if [ $OPENRESTY_PATCHES != 0 ]; then
           pushd bundle
             if [ ! -f .patch_applied ]; then
-              for patch_file in $(ls -1 $(realpath $DOWNLOAD_CACHE/openresty-patches)/patches/$OPENRESTY_VER/*.patch); do
+              for patch_file in $(ls -1 $DOWNLOAD_CACHE/openresty-patches/patches/$OPENRESTY_VER/*.patch); do
                 echo "Applying OpenResty patch $patch_file"
                 patch -p1 < $patch_file
               done


### PR DESCRIPTION
Prior to this patch, our OpenResty patches were not being applied. Here
is the output the script would give:

    WARN: Kong OpenResty patches not found, cloning...
    Cloning into 'openresty-patches'...
    ~/code/kong/openresty-build-tools/work/openresty-patches ~/code/kong/openresty-build-tools/work ~/code/kong/openresty-build-tools
    NOTICE: Checking out branch 'master' of Kong's OpenResty patches...
    HEAD is now at 8780af8 chore(ci) bump LuaRocks to 3.1.2
    ~/code/kong/openresty-build-tools/work ~/code/kong/openresty-build-tools
    ~/code/kong/openresty-build-tools
    WARN: Building OpenResty...
    ~/code/kong/openresty-build-tools/work/openresty-1.13.6.2 ~/code/kong/openresty-build-tools
    ~/code/kong/openresty-build-tools/work/openresty-1.13.6.2/bundle ~/code/kong/openresty-build-tools/work/openresty-1.13.6.2 ~/code/kong/openresty-build-tools
    realpath: work/openresty-patches: No such file or directory
    ls: cannot access '/patches/1.13.6.2/*.patch': No such file or directory