### PR TITLE
feat(kong-ngx-build) hardened build failures on missing OpenResty patches

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -248,7 +248,7 @@ main() {
         popd
       popd
     fi
-    
+
     if [ ! -z "$PCRE_VER" ]; then
       PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
       if [ ! -d $PCRE_DOWNLOAD ]; then
@@ -281,7 +281,7 @@ main() {
           "--with-stream_realip_module"
           "-j$NPROC"
         )
-        
+
         if [ ! -z "$PCRE_VER" ]; then
           OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')
         fi
@@ -306,7 +306,7 @@ main() {
             fi
           popd
 
-          if [[ ! -f "bundle/.patch_applied" ]]; then
+          if [ ! -f bundle/.patch_applied ]; then
             fatal "missing .patch_applied file; some OpenResty patches may not have been applied"
           fi
         fi
@@ -338,7 +338,7 @@ main() {
   if [ ! -z "$LUAROCKS_VER" ]; then
     LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
     LUAROCKS_DESTDIR=${LUAROCKS_DESTDIR:-/}
-    
+
     if [ ! -f $LUAROCKS_DESTDIR$LUAROCKS_INSTALL/bin/luarocks ]; then
       LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS_VER
 

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -298,12 +298,17 @@ main() {
             if [ ! -f .patch_applied ]; then
               for patch_file in $(ls -1 $DOWNLOAD_CACHE/openresty-patches/patches/$OPENRESTY_VER/*.patch); do
                 echo "Applying OpenResty patch $patch_file"
-                patch -p1 < $patch_file
+                patch -p1 < $patch_file \
+                  || fatal "failed to apply patch: $patch_file"
               done
 
               touch .patch_applied
             fi
           popd
+
+          if [[ ! -f "bundle/.patch_applied" ]]; then
+            fatal "missing .patch_applied file; some OpenResty patches may not have been applied"
+          fi
         fi
 
         # apply non Kong-specific patches


### PR DESCRIPTION


* Added a fatal warning for visibility when a given patch failed to
  apply
* Added a sanity check ensuring the .patch_applied file was written,
  since there can be other failures in the patching code branch than the
  `patch` command itself. E.g. a failure in the `for` command list, not
  caught by `set -e`, as observed recently in 85b17143 (#17).