### PR TITLE
Refactor: optimize steps ordering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 work
 buildroot
+*.log

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -155,27 +155,136 @@ main() {
 
   mkdir -p $DOWNLOAD_CACHE $PREFIX
 
-  notice "Building the components now..."
-
   OPENSSL_INSTALL=${OPENSSL_INSTALL:-$PREFIX/openssl}
   OPENSSL_DESTDIR=${OPENSSL_DESTDIR:-/}
   OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
   OPENRESTY_INSTALL=${OPENRESTY_INSTALL:-$PREFIX/openresty}
   OPENRESTY_DESTDIR=${OPENRESTY_DESTDIR:-/}
 
-  if [ ! -f $OPENSSL_DESTDIR$OPENSSL_INSTALL/bin/openssl ]; then
-    if [ ! -d $OPENSSL_DOWNLOAD ]; then
+  notice "Downloading the components now..."
+
+  pushd $DOWNLOAD_CACHE
+    # OpenSSL
+
+    if [[ ! -f $OPENSSL_DESTDIR$OPENSSL_INSTALL/bin/openssl && ! -d $OPENSSL_DOWNLOAD ]]; then
       warn "OpenSSL source not found, downloading..."
-      pushd $DOWNLOAD_CACHE
-        curl -sSLO https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
-        if [ ! -z ${OPENSSL_SHA+x} ]; then
-          echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
-        fi
-        tar -xzvf openssl-$OPENSSL_VER.tar.gz
-        ln -s openssl-$OPENSSL_VER openssl
-      popd
+      curl -sSLO https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
+      if [ ! -z ${OPENSSL_SHA+x} ]; then
+        echo "$OPENSSL_SHA openssl-$OPENSSL_VER.tar.gz" | sha256sum -c -
+      fi
+      tar -xzvf openssl-$OPENSSL_VER.tar.gz
+      ln -s openssl-$OPENSSL_VER openssl
     fi
 
+    # OpenResty
+
+    if [ ! -f $OPENRESTY_DESTDIR$OPENRESTY_INSTALL/nginx/sbin/nginx ]; then
+      if [[ $OPENRESTY_PATCHES == 0 && -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]]; then
+        warn "Patched OpenResty found but vanilla requested, removing source..."
+        rm -rf $OPENRESTY_DOWNLOAD
+
+      elif [[ $OPENRESTY_PATCHES != 0 && ! -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]]; then
+        warn "Vanilla OpenResty found but patches requested, removing Makefile..."
+        rm -f $OPENRESTY_DOWNLOAD/Makefile
+      fi
+
+      if [ ! -d $OPENRESTY_DOWNLOAD ]; then
+        warn "OpenResty source not found, downloading..."
+        curl -sSLO https://openresty.org/download/openresty-$OPENRESTY_VER.tar.gz
+        if [ ! -z ${OPENRESTY_SHA+x} ]; then
+          echo "$OPENRESTY_SHA openresty-$OPENRESTY_VER.tar.gz" | sha256sum -c -
+        fi
+        tar -xzvf openresty-$OPENRESTY_VER.tar.gz
+      fi
+    fi
+
+    # PCRE
+
+    if [ ! -z "$PCRE_VER" ]; then
+      PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
+      if [ ! -d $PCRE_DOWNLOAD ]; then
+        warn "PCRE source not found, downloading..."
+        curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VER}.tar.gz
+        if [ ! -z ${PCRE_SHA+x} ]; then
+          echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
+        fi
+        tar -xzvf pcre-${PCRE_VER}.tar.gz
+        ln -s pcre-$OPENSSL_VER pcre
+      fi
+    fi
+
+    # LuaRocks
+
+    if [ ! -z "$LUAROCKS_VER" ]; then
+      LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
+      LUAROCKS_DESTDIR=${LUAROCKS_DESTDIR:-/}
+      if [ ! -f $LUAROCKS_DESTDIR$LUAROCKS_INSTALL/bin/luarocks ]; then
+        LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS_VER
+        if [ ! -d $LUAROCKS_DOWNLOAD ]; then
+          warn "LuaRocks source not found, downloading..."
+          curl -sSLO https://luarocks.org/releases/luarocks-$LUAROCKS_VER.tar.gz
+          if [ ! -z ${LUAROCKS_SHA+x} ]; then
+            echo "$LUAROCKS_SHA luarocks-$LUAROCKS_VER.tar.gz" | sha256sum -c -
+          fi
+          tar -xzvf luarocks-$LUAROCKS_VER.tar.gz
+        fi
+      fi
+    fi
+  popd
+
+  notice "Patching the components now..."
+
+  if [ ! -f $OPENRESTY_DESTDIR$OPENRESTY_INSTALL/nginx/sbin/nginx ]; then
+    notice "Patching OpenResty..."
+
+    if [[ $OPENRESTY_PATCHES != 0 ]]; then
+      pushd $DOWNLOAD_CACHE
+        if [[ ! -d "openresty-patches" ]]; then
+          warn "Kong OpenResty patches not found, cloning..."
+          git clone https://github.com/Kong/openresty-patches
+        fi
+
+        pushd openresty-patches
+          notice "Checking out branch '$OPENRESTY_PATCHES' of Kong's OpenResty patches..."
+          git fetch
+          git reset --hard origin/$OPENRESTY_PATCHES
+        popd
+      popd
+
+      pushd $OPENRESTY_DOWNLOAD/bundle
+        if [ ! -f .patch_applied ]; then
+          for patch_file in $(ls -1 $DOWNLOAD_CACHE/openresty-patches/patches/$OPENRESTY_VER/*.patch); do
+            notice "Applying OpenResty patch $patch_file"
+            patch -p1 < $patch_file \
+              || fatal "failed to apply patch: $patch_file"
+          done
+
+          touch .patch_applied
+        fi
+      popd
+
+      if [ ! -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]; then
+        fatal "missing .patch_applied file; some OpenResty patches may not have been applied"
+      fi
+    fi
+
+    # apply non Kong-specific patches
+
+    if [[ $OPENRESTY_VER == 1.13.6.* ]]; then
+      if [[ $OS == "Fedora" && $OS_VER -gt 28 ]]; then
+        warn "Fedora 28 or above detected, applying 'rm_glibc_crypt_r_workaround' patch..."
+        pushd $OPENRESTY_DOWNLOAD/bundle/nginx-1.13.6
+          patch --forward -p1 < $SCRIPT_PATH/patches/nginx-1.13.6-rm_glibc_crypt_r_workaround.patch || true
+        popd
+      fi
+    fi
+  fi
+
+  notice "Building the components now..."
+
+  # Building OpenSSL
+
+  if [ ! -f $OPENSSL_DESTDIR$OPENSSL_INSTALL/bin/openssl ]; then
     notice "Building OpenSSL..."
 
     pushd $OPENSSL_DOWNLOAD
@@ -213,58 +322,10 @@ main() {
     succ "OpenSSL $OPENSSL_VER has been built successfully (cached)!"
   fi
 
+  # Building OpenResty
+
   if [ ! -f $OPENRESTY_DESTDIR$OPENRESTY_INSTALL/nginx/sbin/nginx ]; then
-    if [[ $OPENRESTY_PATCHES == 0 && -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]]; then
-      notice "Patched OpenResty found, removing..."
-      rm -rf $OPENRESTY_DOWNLOAD
-
-    elif [[ $OPENRESTY_PATCHES != 0 && ! -f $OPENRESTY_DOWNLOAD/bundle/.patch_applied ]]; then
-      rm -f $OPENRESTY_DOWNLOAD/Makefile
-    fi
-
-
-    if [ ! -d $OPENRESTY_DOWNLOAD ]; then
-      warn "OpenResty source not found, downloading..."
-      pushd $DOWNLOAD_CACHE
-        curl -sSLO https://openresty.org/download/openresty-$OPENRESTY_VER.tar.gz
-        if [ ! -z ${OPENRESTY_SHA+x} ]; then
-          echo "$OPENRESTY_SHA openresty-$OPENRESTY_VER.tar.gz" | sha256sum -c -
-        fi
-        tar -xzvf openresty-$OPENRESTY_VER.tar.gz
-      popd
-    fi
-
-    if [[ $OPENRESTY_PATCHES != 0 ]]; then
-      pushd $DOWNLOAD_CACHE
-        if [[ ! -d "openresty-patches" ]]; then
-          warn "Kong OpenResty patches not found, cloning..."
-          git clone https://github.com/Kong/openresty-patches
-        fi
-
-        pushd openresty-patches
-          notice "Checking out branch '$OPENRESTY_PATCHES' of Kong's OpenResty patches..."
-          git fetch
-          git reset --hard origin/$OPENRESTY_PATCHES
-        popd
-      popd
-    fi
-
-    if [ ! -z "$PCRE_VER" ]; then
-      PCRE_DOWNLOAD=$DOWNLOAD_CACHE/pcre-$PCRE_VER
-      if [ ! -d $PCRE_DOWNLOAD ]; then
-        warn "PCRE source not found, downloading..."
-        pushd $DOWNLOAD_CACHE
-          curl -sSLO https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VER}.tar.gz
-          if [ ! -z ${PCRE_SHA+x} ]; then
-            echo "$PCRE_SHA pcre-${PCRE_VER}.tar.gz" | sha256sum -c -
-          fi
-          tar -xzvf pcre-${PCRE_VER}.tar.gz
-          ln -s pcre-$OPENSSL_VER pcre
-        popd
-      fi
-    fi
-
-    warn "Building OpenResty..."
+    notice "Building OpenResty..."
 
     pushd $OPENRESTY_DOWNLOAD
       if [ ! -f Makefile ]; then
@@ -293,35 +354,6 @@ main() {
           OPENRESTY_OPTS+=('--with-luajit-xcflags="-DLUAJIT_USE_VALGRIND -DLUA_USE_ASSERT -DLUA_USE_APICHECK -DLUAJIT_USE_SYSMALLOC"')
         fi
 
-        if [ $OPENRESTY_PATCHES != 0 ]; then
-          pushd bundle
-            if [ ! -f .patch_applied ]; then
-              for patch_file in $(ls -1 $DOWNLOAD_CACHE/openresty-patches/patches/$OPENRESTY_VER/*.patch); do
-                echo "Applying OpenResty patch $patch_file"
-                patch -p1 < $patch_file \
-                  || fatal "failed to apply patch: $patch_file"
-              done
-
-              touch .patch_applied
-            fi
-          popd
-
-          if [ ! -f bundle/.patch_applied ]; then
-            fatal "missing .patch_applied file; some OpenResty patches may not have been applied"
-          fi
-        fi
-
-        # apply non Kong-specific patches
-
-        if [[ $OPENRESTY_VER == 1.13.6.* ]]; then
-          if [[ $OS == "Fedora" && $OS_VER -gt 28 ]]; then
-            notice "Fedora 28 or above detected, applying 'rm_glibc_crypt_r_workaround' patch..."
-            pushd bundle/nginx-1.13.6
-              patch --forward -p1 < $SCRIPT_PATH/patches/nginx-1.13.6-rm_glibc_crypt_r_workaround.patch || true
-            popd
-          fi
-        fi
-
         eval ./configure ${OPENRESTY_OPTS[*]}
       fi
 
@@ -335,25 +367,11 @@ main() {
     succ "OpenResty $OPENRESTY_VER has been built successfully (cached)!"
   fi
 
+  # Building LuaRocks
+
   if [ ! -z "$LUAROCKS_VER" ]; then
-    LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
-    LUAROCKS_DESTDIR=${LUAROCKS_DESTDIR:-/}
-
     if [ ! -f $LUAROCKS_DESTDIR$LUAROCKS_INSTALL/bin/luarocks ]; then
-      LUAROCKS_DOWNLOAD=$DOWNLOAD_CACHE/luarocks-$LUAROCKS_VER
-
-      if [ ! -d $LUAROCKS_DOWNLOAD ]; then
-        warn "LuaRocks source not found, downloading..."
-        pushd $DOWNLOAD_CACHE
-          curl -sSLO https://luarocks.org/releases/luarocks-$LUAROCKS_VER.tar.gz
-          if [ ! -z ${LUAROCKS_SHA+x} ]; then
-            echo "$LUAROCKS_SHA luarocks-$LUAROCKS_VER.tar.gz" | sha256sum -c -
-          fi
-          tar -xzvf luarocks-$LUAROCKS_VER.tar.gz
-        popd
-      fi
-
-      warn "Building LuaRocks..."
+      notice "Building LuaRocks..."
 
       pushd $LUAROCKS_DOWNLOAD
         if [ ! -f config.unix ]; then

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -9,8 +9,7 @@ OPENRESTY_VER=
 OPENSSL_VER=
 LUAROCKS_VER=
 PCRE_VER=
-BUILD_CACHE=1
-ARTIFACT_CACHE=1
+FORCE=0
 OPENRESTY_PATCHES=master
 DEBUG=0
 NPROC=`nproc`
@@ -63,14 +62,6 @@ main() {
         LUAROCKS_SHA=$2
         shift 2
         ;;
-      --no-build-cache)
-        BUILD_CACHE=0
-        shift 1
-        ;;
-      --no-artifact-cache)
-        ARTIFACT_CACHE=0
-        shift 1
-        ;;
       --no-openresty-patches)
         OPENRESTY_PATCHES=0
         shift 1
@@ -78,6 +69,10 @@ main() {
       --openresty-patches)
         OPENRESTY_PATCHES=$2
         shift 2
+        ;;
+      -f|--force)
+        FORCE=1
+        shift 1
         ;;
       --debug)
         DEBUG=1
@@ -142,12 +137,8 @@ main() {
     OS_VER=$(lsb_release -sr)
   fi
 
-  if [ $BUILD_CACHE == 0 ]; then
-      rm -rf $DOWNLOAD_CACHE
-  fi
-
-  if [ $ARTIFACT_CACHE == 0 ]; then
-      rm -rf $PREFIX
+  if [ $FORCE == 1 ]; then
+    rm -rf $PREFIX $DOWNLOAD_CACHE
   fi
 
   OPENSSL_DOWNLOAD=$DOWNLOAD_CACHE/openssl-$OPENSSL_VER
@@ -393,10 +384,6 @@ main() {
     fi
   fi
 
-  if [ $BUILD_CACHE == 0 ]; then
-      rm -rf $DOWNLOAD_CACHE
-  fi
-
   succ "Build finished in $SECONDS seconds. Enjoy!"
 }
 
@@ -411,12 +398,6 @@ show_usage() {
   echo "      --openssl <openssl_ver>      Version of OpenSSL to build, such as 1.1.1c."
   echo ""
   echo "Optional arguments:"
-  echo "      --no-build-cache             Build from scratch."
-  echo -e "                                   (\033[1;31mWARNING:\033[0m this removes everything inside the work directory)"
-  echo ""
-  echo "      --no-artifact-cache          Disable artifact caching and re-install all the softwares."
-  echo -e "                                   (\033[1;31mWARNING:\033[0m this removes everything inside the prefix directory)"
-  echo ""
   echo "      --no-openresty-patches       Do not apply openresty-patches while compiling OpenResty."
   echo "                                   (Patching is enabled by default)"
   echo ""
@@ -439,8 +420,11 @@ show_usage() {
   echo "  -j, --jobs                       Concurrency level to use when building."
   echo "                                   (Defaults to number of CPU cores available: $NPROC)"
   echo ""
-  echo "      --work <work_dir>            The working directory to use while compiling."
+  echo "      --work <work>                The working directory to use while compiling."
   echo "                                   (Defaults to \"work\")"
+  echo ""
+  echo "  -f, --force                      Build from scratch."
+  echo -e "                                   (\033[1;31mWARNING:\033[0m this removes everything inside the <work> and <prefix> directories)"
   echo ""
   echo "  -h, --help                       Show this message."
 }


### PR DESCRIPTION
##### reorganize script's steps

1. Download all necessary components
2. Patch all necessary components
3. Build all necessary components

This way, errors in steps 1. and 2. can be seen much sooner when running
the script.

---

##### replace '--no-*-cache' options with '--force'

* At least one of these options did not seem to be doing what it said it
  would do.
* This level of granularity with regards to cleaning prefix, work, or
  both is probably not needed: both is most likely what the user always
  wants.
* Having both options is more confusing than anything, and their names
  are too long to be efficiently used.