### PR TITLE
fix(luarocks) install luarocks to system and to destdir

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -320,6 +320,7 @@ main() {
       fi
 
       make -j$NPROC
+      make -j$NPROC install
       make -j$NPROC install DESTDIR=${OPENRESTY_DESTDIR}
     popd
 
@@ -328,6 +329,7 @@ main() {
   else
     succ "OpenResty $OPENRESTY_VER has been built successfully (cached)!"
   fi
+  
 
   if [ ! -z "$LUAROCKS_VER" ]; then
     LUAROCKS_INSTALL=${LUAROCKS_INSTALL:-$PREFIX/luarocks}
@@ -353,9 +355,8 @@ main() {
         if [ ! -f config.unix ]; then
           ./configure \
             --prefix=$LUAROCKS_INSTALL \
-            --lua-suffix=jit \
-            --with-lua=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit \
-            --with-lua-include=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit/include/luajit-2.1
+            --with-lua=$OPENRESTY_INSTALL/luajit \
+            --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1
         fi
 
         make build -j$NPROC


### PR DESCRIPTION
This is to fix a packaging specific issue where Kong requirements are built to one directory, packaged then installed into another.

Building / installing luarocks with
```
            --with-lua=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit \
            --with-lua-include=$OPENRESTY_DESTDIR$OPENRESTY_INSTALL/luajit/include/luajit-2.1
```

leads to
```
Error: Failed finding Lua library. You may need to configure LUA_LIBDIR.
```
when trying to install things via `luarocks install version` for example

switching to
```
            --with-lua=$OPENRESTY_INSTALL/luajit \
            --with-lua-include=$OPENRESTY_INSTALL/luajit/include/luajit-2.1
```
is correct for the end result but during build time doesn't work since lua isn't at that location. So to resolve that we're installing lua twice once to the temporary location and once to the final end result