### PR TITLE
Fix version checking corner cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ stages:
 jobs:
  include:
    - stage: unit tests
-     script: for f in t/*.sh; do bash $f; done
+     script: bash t/*.sh
      env:
 
 install:

--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -413,7 +413,7 @@ parse_version() {
 
   local subj=$1
   local -n ver=$2
-  local re='^(-rc[0-9]+$)?[^0-9]*([0-9a-zA-Z]*)(.*?)$'
+  local re='^(-rc[0-9]+$)?[^0-9]*([0-9a-zA-Z]*)(.*)$'
 
   while [[ $subj =~ $re ]]; do
     if [[ ${BASH_REMATCH[1]} != "" ]]; then

--- a/t/001_test_version.sh
+++ b/t/001_test_version.sh
@@ -51,6 +51,8 @@ t "version_lt 1.11.10 1.11.11" 0
 t "version_lt 1.10.11 1.11.11" 0
 t "version_lt 0.11.11 1.11.11" 0
 t "version_lt 1.11.10.11.11 1.11.11.11.11" 0
+# Check that it's not using direct string comparison
+t "version_lt 1.11.99 1.11.100" 0
 
 t "version_lt 1.11.0 1.11.0" 1
 t "version_lt 1.12.0 1.11.0" 1


### PR DESCRIPTION
At the moment, there are a couple of corner cases that do not work:

### Direct string comparison

Currently `version_lt` is comparing strings, so `version_lt 99 100` has 1 exit code (false). I have added a test that should be failing: https://travis-ci.com/Kong/openresty-build-tools/jobs/211899987#L243

Reference implementation took care of that case: https://github.com/Kong/openresty-build-tools/blob/e2d7f944aab6d9aa4a9e31705e4a3ce8716871e7/kong-ngx-build#L430-L440

### Bash versions

* `local -n` is not supported on bash 3
* the regular expression does not match somehow on my setup. Inside docker it works on both bash 4, and 5. But on my host, even compiling bash from source, still it does not enter the regular expression match loop, very strange!

I created this to try to reproduce it:

```
re='^(-rc[0-9]+$)?[^0-9]*([0-9a-zA-Z]*)(.*?)$'

if [[ "1.10.20" =~ $re ]]; then
  echo "IT MATCHES"
else
  echo "IT DOES NOT MATCH"
fi
```

```shell
$ bash test.sh
IT DOES NOT MATCH
$ docker run --rm -it --volume $(realpath .):/build ubuntu bash
root@ba783c8f40a7:/# cd /build/
root@ba783c8f40a7:/build# bash test.sh
IT MATCHES
root@ba783c8f40a7:/build#
```

Somehow, the lazy quantifier is not working on (my) bsd regex (os x), even though `man 3 regex` says otherwise:

```
A repetition operator (`?', `*', `+', or bounds) cannot follow another repetition operator, except for the use of `?' for minimal repetition (for enhanced extended REs; see
     re_format(7) for details).  A repetition operator cannot begin an expression or subexpression or follow `^' or `|'.
```