### PR TITLE
hotfix(kong-ngx-build) ensure the 'pcre_version()' symbol is preserved and undefined when PCRE is statically linked.

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -334,10 +334,10 @@ main() {
     pushd $OPENRESTY_DOWNLOAD
       if [ ! -f Makefile ]; then
         OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
+        OPENRESTY_CC_OPT="-I$OPENSSL_INSTALL/include"
+        OPENRESTY_LD_OPT="-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH"
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_PREFIX"
-          "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
-          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"
@@ -356,8 +356,11 @@ main() {
 
         if [ ! -z "$PCRE_VER" ]; then
           OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')
+          OPENRESTY_LD_OPT="$OPENRESTY_LD_OPT -Wl,--undefined=pcre_version"
         fi
 
+        OPENRESTY_OPTS+=("--with-cc-opt='${OPENRESTY_CC_OPT}'")
+        OPENRESTY_OPTS+=("--with-ld-opt='${OPENRESTY_LD_OPT}'")
         OPENRESTY_OPTS+=(${NGINX_EXTRA_MODULES[@]})
 
         if [ $DEBUG == 1 ]; then


### PR DESCRIPTION
A temporary hotfix until the issue is addressed in upstream OpenResty (a
patch has already been written).

When using `--with-pcre=...`, NGINX is statically linked against
libpcre.a. Since `pcre_version()` is unused, its symbol is stripped by
the linker. Because lua-resty-core's `resty.core.regex` module needs it,
we here ensure that the symbol is entered as undefined in our final
binary.