### PR TITLE
refactor(kong-ngx-build) new fix for static PCRE builds with OpenResty 1.15.8.1

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -267,9 +267,18 @@ main() {
 
     if version_lt $NGINX_CORE_VER 1.15.0; then # this is fixed in Nginx 1.15.0
       if [[ $OS == "Fedora" && $OS_VER -gt 28 ]]; then
-        warn "Fedora 28 or above detected, applying 'rm_glibc_crypt_r_workaround' patch..."
+        warn "Fedora 28 or above detected, applying the 'rm_glibc_crypt_r_workaround' patch..."
         pushd $OPENRESTY_DOWNLOAD/bundle/nginx-$NGINX_CORE_VER
           patch --forward -p1 < $SCRIPT_PATH/patches/nginx-$NGINX_CORE_VER-rm_glibc_crypt_r_workaround.patch || true
+        popd
+      fi
+    fi
+
+    if version_eq $OPENRESTY_VER 1.15.8.1; then # this appeared in OpenResty 1.15.8.1 and is fixed in later versions
+      if [ ! -z "$PCRE_VER" ]; then
+        warn "Building OpenResty 1.15.8.1 with static libpcre, applying the 'fix_static_libpcre_linking' patch..."
+        pushd $OPENRESTY_DOWNLOAD/bundle/ngx_lua-0.10.15
+          patch --forward -p1 < $SCRIPT_PATH/patches/openresty-$OPENRESTY_VER-fix_static_libpcre_linking.patch || true
         popd
       fi
     fi
@@ -334,10 +343,10 @@ main() {
     pushd $OPENRESTY_DOWNLOAD
       if [ ! -f Makefile ]; then
         OPENRESTY_RPATH=${OPENRESTY_RPATH:-$OPENSSL_INSTALL/lib}
-        OPENRESTY_CC_OPT="-I$OPENSSL_INSTALL/include"
-        OPENRESTY_LD_OPT="-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH"
         OPENRESTY_OPTS=(
           "--prefix=$OPENRESTY_PREFIX"
+          "--with-cc-opt='-I$OPENSSL_INSTALL/include'"
+          "--with-ld-opt='-L$OPENSSL_INSTALL/lib -Wl,-rpath,$OPENRESTY_RPATH'"
           "--with-pcre-jit"
           "--with-http_ssl_module"
           "--with-http_realip_module"
@@ -356,11 +365,8 @@ main() {
 
         if [ ! -z "$PCRE_VER" ]; then
           OPENRESTY_OPTS+=('--with-pcre=$PCRE_DOWNLOAD')
-          OPENRESTY_LD_OPT="$OPENRESTY_LD_OPT -Wl,--undefined=pcre_version"
         fi
 
-        OPENRESTY_OPTS+=("--with-cc-opt='${OPENRESTY_CC_OPT}'")
-        OPENRESTY_OPTS+=("--with-ld-opt='${OPENRESTY_LD_OPT}'")
         OPENRESTY_OPTS+=(${NGINX_EXTRA_MODULES[@]})
 
         if [ $DEBUG == 1 ]; then

--- a/patches/openresty-1.15.8.1-fix_static_libpcre_linking.patch
+++ b/patches/openresty-1.15.8.1-fix_static_libpcre_linking.patch
@@ -1,0 +1,51 @@
+From 2014dd80fe4f299ad68c3b60a2c5f846b4286b6f Mon Sep 17 00:00:00 2001
+From: Thibault Charbonnier <thibaultcha@me.com>
+Date: Wed, 10 Jul 2019 22:41:29 -0700
+Subject: [PATCH] bugfix: ensured the 'pcre_version' symbol is preserved as
+ undefined when PCRE is statically linked.
+
+When using `--with-pcre=...`, NGINX is statically linked against
+libpcre.a. Since `pcre_version()` is unused, its symbol is stripped by
+the linker. Because lua-resty-core's `resty.core.regex` module needs it,
+we here ensure that the symbol is entered as undefined in our final
+binary.
+
+This should not be an issue for win32 builds since
+`--export-all-symbols` is already set.
+---
+ config | 22 ++++++++++++++++++++++
+ 1 file changed, 22 insertions(+)
+
+diff --git a/config b/config
+index 3ef8f0749..ff44482bc 100644
+--- a/config
++++ b/config
+@@ -588,5 +588,27 @@ else
+     CORE_LIBS="$CORE_LIBS $ngx_module_libs"
+ fi
+ 
++# ----------------------------------------
++
++if [ $PCRE != NO -a $PCRE != YES ]; then
++    # force pcre_version symbol to be undefined when PCRE is statically linked
++
++    ngx_feature="force undefined symbols (--undefined)"
++    ngx_feature_libs="-Wl,--undefined=printf"
++    ngx_feature_name=
++    ngx_feature_run=no
++    ngx_feature_incs="#include <stdio.h>"
++    ngx_feature_path=
++    ngx_feature_test='printf("hello");'
++
++    . auto/feature
++
++    if [ $ngx_found = yes ]; then
++        CORE_LIBS="$CORE_LIBS -Wl,--undefined=pcre_version"
++    fi
++fi
++
++# ----------------------------------------
++
+ #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_PATH='\"/usr/local/openresty/lualib/?.lua\"'"
+ #CFLAGS=$"$CFLAGS -DLUA_DEFAULT_CPATH='\"/usr/local/openresty/lualib/?.so\"'"
+


### PR DESCRIPTION
This reverts commit 83bf2d4f5e1df3f19f6b260e47a8864c0ad5df54 and
provides the fix as an OpenResty patch (not Kong-specific, hence not
added to the openresty-patches repository).

This patch will be less maintenance over time since it won't require
further updates when compiling future versions of OpenResty.