### PR TITLE
fix(kong-ngx-build) fix detection of lua-kong-nginx-module download

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -243,7 +243,7 @@ main() {
     # lua-kong-nginx-module
     if [ $KONG_NGINX_MODULE != 0 ]; then
       pushd $DOWNLOAD_CACHE
-        if [ ! -d $KONG_NGINX_MODULE ]; then
+        if [ ! -d lua-kong-nginx-module ]; then
           warn "lua-kong-nginx-module source not found, cloning..."
           git clone https://github.com/Kong/lua-kong-nginx-module
         fi


### PR DESCRIPTION
The $KONG_NGINX_MODULE contains the name of the branch in use,
not the path.