### PR TITLE
feat(openresty-patches) allow using local patches

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -11,6 +11,7 @@ LUAROCKS_VER=
 PCRE_VER=
 FORCE=0
 OPENRESTY_PATCHES=master
+OPENRESTY_PATCHES_DIR=
 KONG_NGINX_MODULE=master
 DEBUG=0
 NPROC=`nproc`
@@ -69,6 +70,10 @@ main() {
         ;;
       --openresty-patches)
         OPENRESTY_PATCHES=$2
+        shift 2
+        ;;
+      --openresty-patches-dir)
+        OPENRESTY_PATCHES_DIR=$2
         shift 2
         ;;
       --kong-nginx-module)
@@ -262,22 +267,29 @@ main() {
     notice "Patching OpenResty..."
 
     if [[ $OPENRESTY_PATCHES != 0 ]]; then
-      pushd $DOWNLOAD_CACHE
-        if [[ ! -d "openresty-patches" ]]; then
-          warn "Kong OpenResty patches not found, cloning..."
-          git clone https://github.com/Kong/openresty-patches
-        fi
+      if [[ -z "$OPENRESTY_PATCHES_DIR" ]]; then
+        pushd $DOWNLOAD_CACHE
+          if [[ ! -d "openresty-patches" ]]; then
+            warn "Kong OpenResty patches not found, cloning..."
+            git clone https://github.com/Kong/openresty-patches
+          fi
 
-        pushd openresty-patches
-          notice "Checking out branch '$OPENRESTY_PATCHES' of Kong's OpenResty patches..."
-          git fetch
-          git reset --hard origin/$OPENRESTY_PATCHES
+          pushd openresty-patches
+            notice "Checking out branch '$OPENRESTY_PATCHES' of Kong's OpenResty patches..."
+            git fetch
+            git reset --hard origin/$OPENRESTY_PATCHES
+          popd
         popd
-      popd
+        OPENRESTY_PATCHES_DIR=$DOWNLOAD_CACHE/openresty-patches/
+      fi
+
+      if [[ ! -d "$OPENRESTY_PATCHES_DIR" ]]; then
+        fatal "directory does not exist: $OPENRESTY_PATCHES_DIR"
+      fi
 
       pushd $OPENRESTY_DOWNLOAD/bundle
         if [ ! -f .patch_applied ]; then
-          for patch_file in $(ls -1 $DOWNLOAD_CACHE/openresty-patches/patches/$OPENRESTY_VER/*.patch); do
+          for patch_file in $(ls -1 $OPENRESTY_PATCHES_DIR/patches/$OPENRESTY_VER/*.patch); do
             notice "Applying OpenResty patch $patch_file"
             patch -p1 < $patch_file \
               || fatal "failed to apply patch: $patch_file"
@@ -564,6 +576,10 @@ show_usage() {
   echo ""
   echo "      --openresty-patches <branch> Specify an openresty-patches branch to use when applying patches."
   echo "                                   (Defaults to \"master\")"
+  echo ""
+  echo "      --openresty-patches-dir <d>  Specify the root directory of a local copy of openresty-patches"
+  echo "                                   to use instead of checking out a branch from the repository."
+  echo ""
   echo "      --no-kong-nginx-module       Do not include lua-kong-nginx-module while patching and compiling OpenResty."
   echo "                                   (Patching and compiling is enabled by default for OpenResty > 1.13.6.1)"
   echo ""


### PR DESCRIPTION
This will allow us to use openresty-build-tools when running
the CI for openresty-patches itself.