### PR TITLE
feat(kong-ngx-build) apply NGINX core patches for HTTP/2 and mp4 modules CVEs

### DIFF
--- a/kong-ngx-build
+++ b/kong-ngx-build
@@ -340,6 +340,40 @@ main() {
         popd
       fi
     fi
+
+    # CVEs - http://nginx.org/en/security_advisories.html
+
+    if version_lt $NGINX_CORE_VER 1.15.6; then # fixed in NGINX 1.15.6+
+      #if version_lt $OPENRESTY_VER 1.13.6.3; then # also included in OpenResty 1.13.6.3+ (not yet released)
+        warn "Applying the patch for CVE-2018-16843 CVE-2018-16844..."
+        pushd $OPENRESTY_DOWNLOAD/bundle/nginx-$NGINX_CORE_VER
+          if [ ! -f $SCRIPT_PATH/patches/nginx-$NGINX_CORE_VER-cve_2018_16843_cve_2018_16844.patch ]; then
+            fatal "Missing patch nginx-$NGINX_CORE_VER-cve_2018_16843_cve_2018_16844.patch"
+          fi
+          patch --forward -p1 < $SCRIPT_PATH/patches/nginx-$NGINX_CORE_VER-cve_2018_16843_cve_2018_16844.patch || true
+        popd
+
+        warn "Applying the patch for CVE-2018-16845..."
+        pushd $OPENRESTY_DOWNLOAD/bundle/nginx-$NGINX_CORE_VER
+          if [ ! -f $SCRIPT_PATH/patches/nginx-patch.2018.mp4.txt ]; then
+            fatal "Missing patch nginx-patch.2018.mp4.txt"
+          fi
+          patch --forward -p0 < $SCRIPT_PATH/patches/nginx-patch.2018.mp4.txt || true
+        popd
+      #fi
+    fi
+
+    if version_lt $NGINX_CORE_VER 1.17.3; then # fixed in NGINX 1.17.3+
+      #if version_lt $OPENRESTY_VER 1.15.8.2; then # also included in OpenResty 1.15.8.2+ (not yet released)
+        warn "Applying the patch for CVE-2019-9511 CVE-2019-9513 CVE-2019-9516..."
+        pushd $OPENRESTY_DOWNLOAD/bundle/nginx-$NGINX_CORE_VER
+          if [ ! -f $SCRIPT_PATH/patches/nginx-$NGINX_CORE_VER-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch ]; then
+            fatal "Missing patch nginx-$NGINX_CORE_VER-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch"
+          fi
+          patch --forward -p1 < $SCRIPT_PATH/patches/nginx-$NGINX_CORE_VER-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch || true
+        popd
+      #fi
+    fi
   fi
 
   notice "Building the components now..."

--- a/patches/nginx-1.11.2-cve_2018_16843_cve_2018_16844.patch
+++ b/patches/nginx-1.11.2-cve_2018_16843_cve_2018_16844.patch
@@ -1,0 +1,87 @@
+From b4a5ea2cc526393c443a3977a8334d0229f53f40 Mon Sep 17 00:00:00 2001
+From: Thibault Charbonnier <thibaultcha@me.com>
+Date: Tue, 13 Aug 2019 16:49:54 -0700
+Subject: [PATCH] 2018
+
+---
+ src/http/v2/ngx_http_v2.c | 25 +++++++++++++++++++++----
+ src/http/v2/ngx_http_v2.h |  2 ++
+ 2 files changed, 23 insertions(+), 4 deletions(-)
+
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 19e5f3a0..cef8b5b5 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -623,6 +623,7 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
+ 
+     h2c->pool = NULL;
+     h2c->free_frames = NULL;
++    h2c->frames = 0;
+     h2c->free_fake_connections = NULL;
+ 
+ #if (NGX_HTTP_SSL)
+@@ -2589,7 +2590,7 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+ 
+         frame->blocked = 0;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         pool = h2c->pool ? h2c->pool : h2c->connection->pool;
+ 
+         frame = ngx_pcalloc(pool, sizeof(ngx_http_v2_out_frame_t));
+@@ -2613,6 +2614,15 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+         frame->last = frame->first;
+ 
+         frame->handler = ngx_http_v2_frame_handler;
++
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+ #if (NGX_DEBUG)
+@@ -4135,13 +4145,20 @@ ngx_http_v2_idle_handler(ngx_event_t *rev)
+ 
+ #endif
+ 
++    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
++                                         ngx_http_v2_module);
++
++    if (h2c->idle++ > 10 * 1000) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++        ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_NO_ERROR);
++        return;
++    }
++
+     c->destroyed = 0;
+     c->idle = 0;
+     ngx_reusable_connection(c, 0);
+ 
+-    h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+-                                         ngx_http_v2_module);
+-
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+         ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 9e738aa5..524e5aff 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -115,6 +115,8 @@ struct ngx_http_v2_connection_s {
+     ngx_http_connection_t           *http_connection;
+ 
+     ngx_uint_t                       processing;
++    ngx_uint_t                       frames;
++    ngx_uint_t                       idle;
+ 
+     size_t                           send_window;
+     size_t                           recv_window;
+-- 
+2.20.1
+

--- a/patches/nginx-1.11.2-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
+++ b/patches/nginx-1.11.2-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
@@ -1,0 +1,150 @@
+From e17715d6f489348a2566aedd203c246e6d364f5d Mon Sep 17 00:00:00 2001
+From: Thibault Charbonnier <thibaultcha@me.com>
+Date: Tue, 13 Aug 2019 16:51:52 -0700
+Subject: [PATCH] 2019
+
+---
+ src/http/v2/ngx_http_v2.c               | 25 +++++++++++++++++++++----
+ src/http/v2/ngx_http_v2.h               |  3 +++
+ src/http/v2/ngx_http_v2_filter_module.c | 22 +++++++++++++++++-----
+ 3 files changed, 41 insertions(+), 9 deletions(-)
+
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index cef8b5b5..b82f57b4 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -245,6 +245,8 @@ ngx_http_v2_init(ngx_event_t *rev)
+ 
+     h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+ 
++    h2c->priority_limit = h2scf->concurrent_streams;
++
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+         ngx_http_close_connection(c);
+@@ -1488,6 +1490,14 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+         header->name.len = h2c->state.field_end - h2c->state.field_start;
+         header->name.data = h2c->state.field_start;
+ 
++        if (header->name.len == 0) {
++            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                          "client sent zero header name length");
++
++            return ngx_http_v2_connection_error(h2c,
++                                                NGX_HTTP_V2_PROTOCOL_ERROR);
++        }
++
+         return ngx_http_v2_state_field_len(h2c, pos, end);
+     }
+ 
+@@ -1737,6 +1747,13 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
+         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+     }
+ 
++    if (--h2c->priority_limit == 0) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many PRIORITY frames");
++
++        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
++    }
++
+     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
+         return ngx_http_v2_state_save(h2c, pos, end,
+                                       ngx_http_v2_state_priority);
+@@ -2795,6 +2812,8 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
+ 
+     h2c->processing++;
+ 
++    h2c->priority_limit += h2scf->concurrent_streams;
++
+     return stream;
+ }
+ 
+@@ -2932,10 +2951,6 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
+     ngx_uint_t                 i;
+     ngx_http_core_srv_conf_t  *cscf;
+ 
+-    if (header->name.len == 0) {
+-        return NGX_ERROR;
+-    }
+-
+     r->invalid_header = 0;
+ 
+     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+@@ -4009,6 +4024,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
+      */
+     pool = stream->pool;
+ 
++    h2c->frames -= stream->frames;
++
+     ngx_http_free_request(stream->request, rc);
+ 
+     if (pool != h2c->state.pool) {
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 524e5aff..89b76e0c 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -117,6 +117,7 @@ struct ngx_http_v2_connection_s {
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
+     ngx_uint_t                       idle;
++    ngx_uint_t                       priority_limit;
+ 
+     size_t                           send_window;
+     size_t                           recv_window;
+@@ -181,6 +182,8 @@ struct ngx_http_v2_stream_s {
+ 
+     ngx_buf_t                       *preread;
+ 
++    ngx_uint_t                       frames;
++
+     ngx_http_v2_out_frame_t         *free_frames;
+     ngx_chain_t                     *free_frame_headers;
+     ngx_chain_t                     *free_bufs;
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 39ff1030..ad877f66 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -974,22 +974,34 @@ static ngx_http_v2_out_frame_t *
+ ngx_http_v2_filter_get_data_frame(ngx_http_v2_stream_t *stream,
+     size_t len, ngx_chain_t *first, ngx_chain_t *last)
+ {
+-    u_char                    flags;
+-    ngx_buf_t                *buf;
+-    ngx_chain_t              *cl;
+-    ngx_http_v2_out_frame_t  *frame;
++    u_char                     flags;
++    ngx_buf_t                 *buf;
++    ngx_chain_t               *cl;
++    ngx_http_v2_out_frame_t   *frame;
++    ngx_http_v2_connection_t  *h2c;
+ 
+     frame = stream->free_frames;
++    h2c = stream->connection;
+ 
+     if (frame) {
+         stream->free_frames = frame->next;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         frame = ngx_palloc(stream->request->pool,
+                            sizeof(ngx_http_v2_out_frame_t));
+         if (frame == NULL) {
+             return NULL;
+         }
++
++        stream->frames++;
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+     flags = last->buf->last_buf ? NGX_HTTP_V2_END_STREAM_FLAG : 0;
+-- 
+2.20.1
+

--- a/patches/nginx-1.13.6-cve_2018_16843_cve_2018_16844.patch
+++ b/patches/nginx-1.13.6-cve_2018_16843_cve_2018_16844.patch
@@ -1,0 +1,76 @@
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 2c621907..83f9c4a4 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -635,6 +635,7 @@ ngx_http_v2_handle_connection(ngx_http_v2_connection_t *h2c)
+ 
+     h2c->pool = NULL;
+     h2c->free_frames = NULL;
++    h2c->frames = 0;
+     h2c->free_fake_connections = NULL;
+ 
+ #if (NGX_HTTP_SSL)
+@@ -2678,7 +2679,7 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+ 
+         frame->blocked = 0;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         pool = h2c->pool ? h2c->pool : h2c->connection->pool;
+ 
+         frame = ngx_pcalloc(pool, sizeof(ngx_http_v2_out_frame_t));
+@@ -2702,6 +2703,15 @@ ngx_http_v2_get_frame(ngx_http_v2_connection_t *h2c, size_t length,
+         frame->last = frame->first;
+ 
+         frame->handler = ngx_http_v2_frame_handler;
++
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+ #if (NGX_DEBUG)
+@@ -4227,12 +4237,19 @@ ngx_http_v2_idle_handler(ngx_event_t *rev)
+ 
+ #endif
+ 
+-    c->destroyed = 0;
+-    ngx_reusable_connection(c, 0);
+-
+     h2scf = ngx_http_get_module_srv_conf(h2c->http_connection->conf_ctx,
+                                          ngx_http_v2_module);
+ 
++    if (h2c->idle++ > 10 * h2scf->max_requests) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++        ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_NO_ERROR);
++        return;
++    }
++
++    c->destroyed = 0;
++    ngx_reusable_connection(c, 0);
++
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+         ngx_http_v2_finalize_connection(h2c, NGX_HTTP_V2_INTERNAL_ERROR);
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 42e0eb13..83dbea31 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -115,6 +115,8 @@ struct ngx_http_v2_connection_s {
+     ngx_http_connection_t           *http_connection;
+ 
+     ngx_uint_t                       processing;
++    ngx_uint_t                       frames;
++    ngx_uint_t                       idle;
+ 
+     size_t                           send_window;
+     size_t                           recv_window;
+-- 
+2.20.1
+

--- a/patches/nginx-1.13.6-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
+++ b/patches/nginx-1.13.6-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
@@ -1,0 +1,139 @@
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 83f9c4a4..db3f09a9 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -249,6 +249,8 @@ ngx_http_v2_init(ngx_event_t *rev)
+ 
+     h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+ 
++    h2c->priority_limit = h2scf->concurrent_streams;
++
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+         ngx_http_close_connection(c);
+@@ -1518,6 +1520,14 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+         header->name.len = h2c->state.field_end - h2c->state.field_start;
+         header->name.data = h2c->state.field_start;
+ 
++        if (header->name.len == 0) {
++            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                          "client sent zero header name length");
++
++            return ngx_http_v2_connection_error(h2c,
++                                                NGX_HTTP_V2_PROTOCOL_ERROR);
++        }
++
+         return ngx_http_v2_state_field_len(h2c, pos, end);
+     }
+ 
+@@ -1775,6 +1785,13 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
+         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+     }
+ 
++    if (--h2c->priority_limit == 0) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many PRIORITY frames");
++
++        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
++    }
++
+     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
+         return ngx_http_v2_state_save(h2c, pos, end,
+                                       ngx_http_v2_state_priority);
+@@ -2884,6 +2901,8 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c)
+ 
+     h2c->processing++;
+ 
++    h2c->priority_limit += h2scf->concurrent_streams;
++
+     return stream;
+ }
+ 
+@@ -3021,10 +3040,6 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
+     ngx_uint_t                 i;
+     ngx_http_core_srv_conf_t  *cscf;
+ 
+-    if (header->name.len == 0) {
+-        return NGX_ERROR;
+-    }
+-
+     r->invalid_header = 0;
+ 
+     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+@@ -4096,6 +4111,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
+      */
+     pool = stream->pool;
+ 
++    h2c->frames -= stream->frames;
++
+     ngx_http_free_request(stream->request, rc);
+ 
+     if (pool != h2c->state.pool) {
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 83dbea31..f5272398 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -117,6 +117,7 @@ struct ngx_http_v2_connection_s {
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
+     ngx_uint_t                       idle;
++    ngx_uint_t                       priority_limit;
+ 
+     size_t                           send_window;
+     size_t                           recv_window;
+@@ -182,6 +183,8 @@ struct ngx_http_v2_stream_s {
+ 
+     ngx_buf_t                       *preread;
+ 
++    ngx_uint_t                       frames;
++
+     ngx_http_v2_out_frame_t         *free_frames;
+     ngx_chain_t                     *free_frame_headers;
+     ngx_chain_t                     *free_bufs;
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 90707850..b73ae40e 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -1167,22 +1167,34 @@ static ngx_http_v2_out_frame_t *
+ ngx_http_v2_filter_get_data_frame(ngx_http_v2_stream_t *stream,
+     size_t len, ngx_chain_t *first, ngx_chain_t *last)
+ {
+-    u_char                    flags;
+-    ngx_buf_t                *buf;
+-    ngx_chain_t              *cl;
+-    ngx_http_v2_out_frame_t  *frame;
++    u_char                     flags;
++    ngx_buf_t                 *buf;
++    ngx_chain_t               *cl;
++    ngx_http_v2_out_frame_t   *frame;
++    ngx_http_v2_connection_t  *h2c;
+ 
+     frame = stream->free_frames;
++    h2c = stream->connection;
+ 
+     if (frame) {
+         stream->free_frames = frame->next;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         frame = ngx_palloc(stream->request->pool,
+                            sizeof(ngx_http_v2_out_frame_t));
+         if (frame == NULL) {
+             return NULL;
+         }
++
++        stream->frames++;
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+     flags = last->buf->last_buf ? NGX_HTTP_V2_END_STREAM_FLAG : 0;
+-- 
+2.20.1
+

--- a/patches/nginx-1.15.8-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
+++ b/patches/nginx-1.15.8-cve_2019_9511_cve_2019_9513_cve_2019_9516.patch
@@ -1,0 +1,196 @@
+From 6dfbc8b1c2116f362bb871efebbf9df576738e89 Mon Sep 17 00:00:00 2001
+From: Sergey Kandaurov <pluknet@nginx.com>
+Date: Tue, 13 Aug 2019 15:43:32 +0300
+Subject: [PATCH 1/3] HTTP/2: reject zero length headers with PROTOCOL_ERROR.
+
+Fixed uncontrolled memory growth if peer sends a stream of
+headers with a 0-length header name and 0-length header value.
+Fix is to reject headers with zero name length.
+---
+ src/http/v2/ngx_http_v2.c | 12 ++++++++----
+ 1 file changed, 8 insertions(+), 4 deletions(-)
+
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 9571e710..72d5aa50 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -1546,6 +1546,14 @@ ngx_http_v2_state_process_header(ngx_http_v2_connection_t *h2c, u_char *pos,
+         header->name.len = h2c->state.field_end - h2c->state.field_start;
+         header->name.data = h2c->state.field_start;
+ 
++        if (header->name.len == 0) {
++            ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                          "client sent zero header name length");
++
++            return ngx_http_v2_connection_error(h2c,
++                                                NGX_HTTP_V2_PROTOCOL_ERROR);
++        }
++
+         return ngx_http_v2_state_field_len(h2c, pos, end);
+     }
+ 
+@@ -3249,10 +3257,6 @@ ngx_http_v2_validate_header(ngx_http_request_t *r, ngx_http_v2_header_t *header)
+     ngx_uint_t                 i;
+     ngx_http_core_srv_conf_t  *cscf;
+ 
+-    if (header->name.len == 0) {
+-        return NGX_ERROR;
+-    }
+-
+     r->invalid_header = 0;
+ 
+     cscf = ngx_http_get_module_srv_conf(r, ngx_http_core_module);
+-- 
+2.20.1
+
+
+From a987f81dd19210bc30b62591db331e31d3d74089 Mon Sep 17 00:00:00 2001
+From: Ruslan Ermilov <ru@nginx.com>
+Date: Tue, 13 Aug 2019 15:43:36 +0300
+Subject: [PATCH 2/3] HTTP/2: limited number of DATA frames.
+
+Fixed excessive memory growth and CPU usage if stream windows are
+manipulated in a way that results in generating many small DATA frames.
+Fix is to limit the number of simultaneously allocated DATA frames.
+---
+ src/http/v2/ngx_http_v2.c               |  2 ++
+ src/http/v2/ngx_http_v2.h               |  2 ++
+ src/http/v2/ngx_http_v2_filter_module.c | 22 +++++++++++++++++-----
+ 3 files changed, 21 insertions(+), 5 deletions(-)
+
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 72d5aa50..88e2bb9f 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -4369,6 +4369,8 @@ ngx_http_v2_close_stream(ngx_http_v2_stream_t *stream, ngx_int_t rc)
+      */
+     pool = stream->pool;
+ 
++    h2c->frames -= stream->frames;
++
+     ngx_http_free_request(stream->request, rc);
+ 
+     if (pool != h2c->state.pool) {
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index bec22160..715b7d30 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -192,6 +192,8 @@ struct ngx_http_v2_stream_s {
+ 
+     ngx_buf_t                       *preread;
+ 
++    ngx_uint_t                       frames;
++
+     ngx_http_v2_out_frame_t         *free_frames;
+     ngx_chain_t                     *free_frame_headers;
+     ngx_chain_t                     *free_bufs;
+diff --git a/src/http/v2/ngx_http_v2_filter_module.c b/src/http/v2/ngx_http_v2_filter_module.c
+index 81e6c513..96f55426 100644
+--- a/src/http/v2/ngx_http_v2_filter_module.c
++++ b/src/http/v2/ngx_http_v2_filter_module.c
+@@ -1669,22 +1669,34 @@ static ngx_http_v2_out_frame_t *
+ ngx_http_v2_filter_get_data_frame(ngx_http_v2_stream_t *stream,
+     size_t len, ngx_chain_t *first, ngx_chain_t *last)
+ {
+-    u_char                    flags;
+-    ngx_buf_t                *buf;
+-    ngx_chain_t              *cl;
+-    ngx_http_v2_out_frame_t  *frame;
++    u_char                     flags;
++    ngx_buf_t                 *buf;
++    ngx_chain_t               *cl;
++    ngx_http_v2_out_frame_t   *frame;
++    ngx_http_v2_connection_t  *h2c;
+ 
+     frame = stream->free_frames;
++    h2c = stream->connection;
+ 
+     if (frame) {
+         stream->free_frames = frame->next;
+ 
+-    } else {
++    } else if (h2c->frames < 10000) {
+         frame = ngx_palloc(stream->request->pool,
+                            sizeof(ngx_http_v2_out_frame_t));
+         if (frame == NULL) {
+             return NULL;
+         }
++
++        stream->frames++;
++        h2c->frames++;
++
++    } else {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "http2 flood detected");
++
++        h2c->connection->error = 1;
++        return NULL;
+     }
+ 
+     flags = last->buf->last_buf ? NGX_HTTP_V2_END_STREAM_FLAG : 0;
+-- 
+2.20.1
+
+
+From 5ae726912654da10a9a81b2c8436829f3e94f69f Mon Sep 17 00:00:00 2001
+From: Ruslan Ermilov <ru@nginx.com>
+Date: Tue, 13 Aug 2019 15:43:40 +0300
+Subject: [PATCH 3/3] HTTP/2: limited number of PRIORITY frames.
+
+Fixed excessive CPU usage caused by a peer that continuously shuffles
+priority of streams.  Fix is to limit the number of PRIORITY frames.
+---
+ src/http/v2/ngx_http_v2.c | 10 ++++++++++
+ src/http/v2/ngx_http_v2.h |  1 +
+ 2 files changed, 11 insertions(+)
+
+diff --git a/src/http/v2/ngx_http_v2.c b/src/http/v2/ngx_http_v2.c
+index 88e2bb9f..e55f9bab 100644
+--- a/src/http/v2/ngx_http_v2.c
++++ b/src/http/v2/ngx_http_v2.c
+@@ -273,6 +273,7 @@ ngx_http_v2_init(ngx_event_t *rev)
+     h2scf = ngx_http_get_module_srv_conf(hc->conf_ctx, ngx_http_v2_module);
+ 
+     h2c->concurrent_pushes = h2scf->concurrent_pushes;
++    h2c->priority_limit = h2scf->concurrent_streams;
+ 
+     h2c->pool = ngx_create_pool(h2scf->pool_size, h2c->connection->log);
+     if (h2c->pool == NULL) {
+@@ -1804,6 +1805,13 @@ ngx_http_v2_state_priority(ngx_http_v2_connection_t *h2c, u_char *pos,
+         return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_SIZE_ERROR);
+     }
+ 
++    if (--h2c->priority_limit == 0) {
++        ngx_log_error(NGX_LOG_INFO, h2c->connection->log, 0,
++                      "client sent too many PRIORITY frames");
++
++        return ngx_http_v2_connection_error(h2c, NGX_HTTP_V2_ENHANCE_YOUR_CALM);
++    }
++
+     if (end - pos < NGX_HTTP_V2_PRIORITY_SIZE) {
+         return ngx_http_v2_state_save(h2c, pos, end,
+                                       ngx_http_v2_state_priority);
+@@ -3120,6 +3128,8 @@ ngx_http_v2_create_stream(ngx_http_v2_connection_t *h2c, ngx_uint_t push)
+         h2c->processing++;
+     }
+ 
++    h2c->priority_limit += h2scf->concurrent_streams;
++
+     return stream;
+ }
+ 
+diff --git a/src/http/v2/ngx_http_v2.h b/src/http/v2/ngx_http_v2.h
+index 715b7d30..69d55d1c 100644
+--- a/src/http/v2/ngx_http_v2.h
++++ b/src/http/v2/ngx_http_v2.h
+@@ -122,6 +122,7 @@ struct ngx_http_v2_connection_s {
+     ngx_uint_t                       processing;
+     ngx_uint_t                       frames;
+     ngx_uint_t                       idle;
++    ngx_uint_t                       priority_limit;
+ 
+     ngx_uint_t                       pushing;
+     ngx_uint_t                       concurrent_pushes;
+-- 
+2.20.1
+

--- a/patches/nginx-patch.2018.mp4.txt
+++ b/patches/nginx-patch.2018.mp4.txt
@@ -1,0 +1,16 @@
+--- src/http/modules/ngx_http_mp4_module.c
++++ src/http/modules/ngx_http_mp4_module.c
+@@ -942,6 +942,13 @@ ngx_http_mp4_read_atom(ngx_http_mp4_file
+                 atom_size = ngx_mp4_get_64value(atom_header + 8);
+                 atom_header_size = sizeof(ngx_mp4_atom_header64_t);
+ 
++                if (atom_size < sizeof(ngx_mp4_atom_header64_t)) {
++                    ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
++                                  "\"%s\" mp4 atom is too small:%uL",
++                                  mp4->file.name.data, atom_size);
++                    return NGX_ERROR;
++                }
++
+             } else {
+                 ngx_log_error(NGX_LOG_ERR, mp4->file.log, 0,
+                               "\"%s\" mp4 atom is too small:%uL",


### PR DESCRIPTION
These patches allow our build script to produce OpenResty 1.13.6.1, 1.13.6.2, and 1.15.8.1 without the recent vulnerabilities found in HTTP/2 and mp4 modules.