### PR TITLE
fix(kong-ngx-build) fix the pcre patch to be compatible with older versions of ld

### DIFF
--- a/patches/openresty-1.15.8.x-fix_static_libpcre_linking.patch
+++ b/patches/openresty-1.15.8.x-fix_static_libpcre_linking.patch
@@ -26,10 +26,10 @@ index e1d5e354..b6270436 100644
 +        ;;
 +
 +        *)
-+            ngx_feature="require defined symbols (--require-defined)"
++            ngx_feature="require defined symbols (--undefined)"
 +            ngx_feature_name=
 +            ngx_feature_path=
-+            ngx_feature_libs="-Wl,--require-defined=strerror"
++            ngx_feature_libs="-Wl,--undefined=strerror"
 +            ngx_feature_run=no
 +            ngx_feature_incs="#include <stdio.h>"
 +            ngx_feature_test='printf("hello");'
@@ -37,7 +37,7 @@ index e1d5e354..b6270436 100644
 +            . auto/feature
 +
 +            if [ $ngx_found = yes ]; then
-+                CORE_LIBS="-Wl,--require-defined=pcre_version $CORE_LIBS"
++                CORE_LIBS="-Wl,--undefined=pcre_version $CORE_LIBS"
 +            fi
 +        ;;
 +    esac


### PR DESCRIPTION
Needed to fix trusty, jessie, centos/rhel 6